### PR TITLE
週間ランキングではグリッド説明を表示しないように

### DIFF
--- a/QiitaCollection/EntryCollectionViewController.swift
+++ b/QiitaCollection/EntryCollectionViewController.swift
@@ -250,7 +250,7 @@ class EntryCollectionViewController: BaseViewController, UICollectionViewDataSou
             self.load()
         }
         
-        if indexPath.row == 0 {
+        if indexPath.row == 0 && ShowType != .WeekRanking  {
             cell.showGuide(GuideManager.GuideType.EntryCollectionCell, inView: self.view)
         }
     }


### PR DESCRIPTION
保持してるデータ上長押しは効かないので
